### PR TITLE
Update basin storage contract

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "evm/basin_storage/lib/forge-std"]
 	path = evm/basin_storage/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "evm/basin_storage/lib/filecoin-solidity"]
-	path = evm/basin_storage/lib/filecoin-solidity
-	url = https://github.com/filecoin-project/filecoin-solidity
 [submodule "evm/basin_storage/lib/openzeppelin-contracts"]
 	path = evm/basin_storage/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/evm/basin_storage/README.md
+++ b/evm/basin_storage/README.md
@@ -1,4 +1,4 @@
-## Foundry
+# Basin Storage Contract
 
 **Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
 
@@ -51,16 +51,53 @@ $ anvil
 $ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
 ```
 
-### Cast
+### Cast commands
+
+#### Add CID
+
+Add a CID to the contract
 
 ```shell
-$ cast <subcommand>
+cast send \
+--private-key <your private key> \
+--rpc-url https://api.calibration.node.glif.io/rpc/v1 \
+<contract adddress> \
+"addCID(string,string,uint256)" \
+"pub.name" \
+"bafyexamplecid" \
+1699615822
 ```
 
-### Help
+#### Get pubs of owner
+
+Get pubs of an owner
 
 ```shell
-$ forge --help
-$ anvil --help
-$ cast --help
+cast call <contract address> \
+--rpc-url "https://api.calibration.node.glif.io/rpc/v1" \
+"pubsOfOwner(address)(string[])" \
+<data owner's address>
+```
+
+#### Get cid at timestamp
+
+Get cid at timestamp (change the timestamp accordingly)
+
+```shell
+cast call <contract address> \
+--rpc-url "https://api.calibration.node.glif.io/rpc/v1" \
+"cidsAtTimestamp(string,uint256)(string[])" \
+"pub.name" \
+1699615822
+```
+
+#### Get cid in time range
+
+Get cid in time range (change timestamps accordingly)
+
+```shell
+cast call <contract address> \
+--rpc-url "https://api.calibration.node.glif.io/rpc/v1" \
+"cidsInRange(string,uint256,uint256)(string[])" \
+"testavichalp.data" 1699615821 1699615823
 ```

--- a/evm/basin_storage/foundry.toml
+++ b/evm/basin_storage/foundry.toml
@@ -4,5 +4,6 @@ out = "out"
 libs = ["lib"]
 solc_version = "0.8.21"
 extra-output-files = ["abi", "bin"]
+via-ir = true
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/evm/basin_storage/remappings.txt
+++ b/evm/basin_storage/remappings.txt
@@ -1,12 +1,5 @@
-@ensdomains/buffer/=lib/filecoin-solidity/lib/buffer/
-@zondax/solidity-bignumber/=lib/filecoin-solidity/vendor/solidity-BigNumber/
-buffer/=lib/filecoin-solidity/lib/buffer/contracts/
 ds-test/=lib/forge-std/lib/ds-test/src/
 erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/
-filecoin-solidity/=lib/filecoin-solidity/
 forge-std/=lib/forge-std/src/
 openzeppelin-contracts/=lib/openzeppelin-contracts/
 openzeppelin/=lib/openzeppelin-contracts/contracts/
-solidity-BigNumber/=lib/filecoin-solidity/vendor/solidity-BigNumber/src/
-solidity-cborutils/=lib/filecoin-solidity/lib/solidity-cborutils/contracts/
-solidity-cborutils/contracts/=lib/filecoin-solidity/lib/solidity-cborutils/contracts/

--- a/evm/basin_storage/script/BasinStorage.s.sol
+++ b/evm/basin_storage/script/BasinStorage.s.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.21;
 
 import {Script, console2} from "forge-std/Script.sol";
-
 import {BasinStorage} from "../src/BasinStorage.sol";
 
 contract BasinStorageScript is Script {
@@ -11,12 +10,15 @@ contract BasinStorageScript is Script {
     function run() public {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         address deployerAddress = vm.addr(deployerPrivateKey);
+        console2.log("deployerAddress: %s", deployerAddress);
+
         vm.startBroadcast(deployerPrivateKey);
 
         BasinStorage basinStorage = new BasinStorage();
 
-        // grant PUB_ADMIN_ROLE to required accounts
-        address pubAdimin2 = 0x0eed5C7ac9D867239A5F550cF94E740f515659Ab;
+        console2.log("Contract Address: %s", address(basinStorage));
+        // grant PUB_ADMIN_ROLE to required accounts (basin staging wallet)
+        address pubAdimin2 = 0x1D3888b19E973E3341960a1938e51e40875a6A15;
         basinStorage.grantRole(basinStorage.PUB_ADMIN_ROLE(), deployerAddress);
         basinStorage.grantRole(basinStorage.PUB_ADMIN_ROLE(), pubAdimin2);
 
@@ -24,19 +26,3 @@ contract BasinStorageScript is Script {
     }
 }
 
-contract BasinStorageCreatePub is Script {
-    function run() public {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        vm.startBroadcast(deployerPrivateKey);
-
-        BasinStorage basinStorage = BasinStorage(
-            vm.envAddress("BASIN_STORAGE")
-        );
-
-        string memory pubName = vm.envString("PUB");
-        address owner = vm.envAddress("OWNER");
-        basinStorage.createPub(owner, pubName);
-
-        vm.stopBroadcast();
-    }
-}

--- a/evm/basin_storage/src/BasinStorage.sol
+++ b/evm/basin_storage/src/BasinStorage.sol
@@ -3,19 +3,9 @@ pragma solidity ^0.8.21;
 
 import {Ownable} from "openzeppelin/access/Ownable.sol";
 import {AccessControl} from "openzeppelin/access/AccessControl.sol";
-import {MarketAPI} from "filecoin-solidity/contracts/v0.8/MarketAPI.sol";
-import {MarketTypes} from "filecoin-solidity/contracts/v0.8/types/MarketTypes.sol";
-import {CommonTypes} from "filecoin-solidity/contracts/v0.8/types/CommonTypes.sol";
 
 contract BasinStorage is AccessControl {
     bytes32 public constant PUB_ADMIN_ROLE = keccak256("PUB_ADMIN_ROLE");
-
-    // DealInfo contains metadata about a Filecoin deal
-    struct DealInfo {
-        uint64 id;
-        string selectorPath;
-        string cid;
-    }
 
     // Pub address by pub name
     mapping(string => address) private _pubs;
@@ -23,18 +13,17 @@ contract BasinStorage is AccessControl {
     // Pubs by owner, a reverse mapping of _pubs
     mapping(address => string[]) private _ownerPubs;
 
-    // deal count by pub
-    mapping(string => uint256) private _pubDealCount;
+    // CID count by pub
+    mapping(string => uint256) private _pubCIDCount;
 
-    // Deal storage indexes by pub, indexed by epoch.
-    mapping(string pub => mapping(uint256 epoch => DealInfo[])) private _deals;
+    // CID storage indexes by pub, indexed by epoch.
+    mapping(string pub => mapping(uint256 epoch => string[])) private _cids;
 
-    // Event to log when a deal is added or updated
-    event DealAdded(
-        uint256 indexed dealId,
+    // Event to log when a CID is indexed
+    event CIDAdded(
+        string indexed cid,
         string indexed pub,
-        address indexed owner,
-        string cid
+        address indexed owner
     );
 
     // Event to log when a pub is created
@@ -48,8 +37,8 @@ contract BasinStorage is AccessControl {
     // PubDoesNotExist is returned when a pub doesn't exist
     error PubDoesNotExist(string reason);
 
-    // DealEpochAlreadyExists is returned when a deal already exists for an epoch
-    error DealEpochAlreadyExists(uint256 epoch);
+    // IncorrectRange is returned when the timestamp range is incorrect
+    error IncorrectRange(uint256 aftr, uint256 before);
 
     constructor() {
         // Set the deployer as the default admin role
@@ -75,194 +64,74 @@ contract BasinStorage is AccessControl {
         emit PubCreated(pub, owner);
     }
 
-    /// @dev Adds the deal info, given deals and a pub.
+    /// @dev Adds the CID for the pub and timestamp.
     ///      Can only be called by the Pub Admin.
-    /// @param deals The Filecoin deal object.
-    /// @param pub The publication to add the deal info for.
-    function addDeals(
+    /// @param pub The publication to add the CID for.
+    /// @param cid The content id for object in the Filecoin deal.
+    /// @param timestamp The timestamp provided by data owner.
+    function addCID(
         string calldata pub,
-        DealInfo[] calldata deals
+        string calldata cid,
+        uint256 timestamp
     ) external onlyRole(PUB_ADMIN_ROLE) {
-        uint256 epoch = block.number;
         address owner = _pubs[pub];
-
         // Pub must already exist
         if (owner == address(0)) {
             revert PubDoesNotExist(pub);
         }
-
-        // Loop through the input deals and add them against an epoch
-        for (uint256 i = 0; i < deals.length; i++) {
-            _deals[pub][epoch].push(deals[i]);
-            _pubDealCount[pub]++;
-            emit DealAdded(deals[i].id, pub, owner, deals[i].cid);
-        }
+        _cids[pub][timestamp].push(cid);
+        _pubCIDCount[pub]++;
+        emit CIDAdded(cid, pub, owner);
     }
 
     /// @dev Returns the pubs of a given data owner.
-    /// @param owner The owner address to get the deals for.
-    /// @return deals The deals for the given data owner.
+    /// @param owner The owner address to get the pubs for.
+    /// @return The pubs for the given data owner.
     function pubsOfOwner(address owner) public view returns (string[] memory) {
         return _ownerPubs[owner];
     }
 
-    /// @dev Returns the given number of deals for a
-    ///      given pub starting from a given epoch.
-    /// @param pub The pub to get the deals for.
-    /// @param startEpoch The epoch to start from.
-    /// @param numDealsToFetch The number of deals to fetch.
-    /// @return deals The deals for the given pub.
-    function _pubDeals(
+    /// @dev Returns the CIDs for a given pub in the given epoch range.
+    /// @param pub The pub to get the CIDs for.
+    /// @param aftr CIDs to fetch after _this_ ts.
+    /// @param before CIDs to fetch before _this_ ts.
+    function cidsInRange(
         string calldata pub,
-        uint256 startEpoch,
-        uint256 numDealsToFetch
-    ) private view returns (DealInfo[] memory) {
-        uint256 lastDealFetchedIdx = 0;
-        DealInfo[] memory deals = new DealInfo[](numDealsToFetch);
+        uint256 aftr,
+        uint256 before
+    ) external view returns (string[] memory) {
+        if (aftr >= before) {
+            revert IncorrectRange(aftr, before);
+        }
+        string[] memory cids = new string[](_pubCIDCount[pub]);
+        uint256 lastCIDFetchedIdx = 0;
 
-        uint256 epoch = startEpoch;
-        // walk backwards until block 0
-        while (epoch >= 0 && lastDealFetchedIdx < numDealsToFetch) {
-            DealInfo[] memory epochDeals = _deals[pub][epoch];
-            for (uint256 i = 0; i < epochDeals.length; i++) {
-                // return if we have fetched the required number of deals
-                if (lastDealFetchedIdx >= numDealsToFetch) {
-                    break;
-                }
-                deals[lastDealFetchedIdx] = epochDeals[i];
-                lastDealFetchedIdx++;
+        uint256 epoch = aftr + 1;
+        while (epoch < before) {
+            string[] memory epochCIDs = _cids[pub][epoch];
+            for (uint256 i = 0; i < epochCIDs.length; i++) {
+                cids[lastCIDFetchedIdx] = epochCIDs[i];
+                lastCIDFetchedIdx++;
             }
-
-            if (epoch == 0) {
-                break;
-            }
-
-            epoch--;
+            epoch++;
         }
 
         // remove the trailing elements if they are empty.
-        // there can be empty array elements towards the end
-        // if NumDealsToFetch is greater than the total deals
-        // available within [epoch, 0]
+        // there can be empty array elements towards the end.
         assembly {
-            mstore(deals, lastDealFetchedIdx)
+            mstore(cids, lastCIDFetchedIdx)
         }
-        return deals;
+        return cids;
     }
 
-    /// @dev Returns the latest N deals for a given pub.
-    /// @param pub The pub to get the deals for.
-    /// @param n The number of deals to fetch.
-    /// @return deals The deals for the given pub.
-    function latestNDeals(
+    /// @dev Returns the CIDs for a given pub at a given epoch.
+    /// @param pub The pub to get the cids for.
+    /// @param epoch The epoch to get the cids for.
+    /// @return cids The CIDs for the given pub at the given epoch.
+    function cidsAtTimestamp(
         string calldata pub,
-        uint256 n
-    ) external view returns (DealInfo[] memory) {
-        uint256 totalDeals = _pubDealCount[pub];
-        // if n is greater than total deals indexed for the pub
-        // set n to total deals
-        n = n > totalDeals ? totalDeals : n;
-
-        return _pubDeals(pub, block.number, n);
-    }
-
-    /// @dev Returns the `limit` number of deals
-    ///      for a given pub, starting from `offset` epoch.
-    /// @param pub The pub to get the deals for.
-    /// @param offset The epoch to start from.
-    /// @param limit The number of deals to fetch.
-    function paginatedDeals(
-        string calldata pub,
-        uint256 offset,
-        uint256 limit
-    ) external view returns (DealInfo[] memory) {
-        uint256 totalDeals = _pubDealCount[pub];
-        // if limit is greater than total deals indexed for the pub
-        // set limit to total deals
-        limit = limit > totalDeals ? totalDeals : limit;
-
-        return _pubDeals(pub, offset, limit);
-    }
-
-    // MARKET API Wrappers
-
-    /// @dev returns the client id for a given deal
-    /// @param dealID the deal id
-    /// @return the client id
-    function dealClient(uint64 dealID) public view returns (uint64) {
-        return MarketAPI.getDealClient(dealID);
-    }
-
-    /// @dev returns the provider id for a given deal
-    /// @param dealID the deal id
-    /// @return the provider id
-    function dealProvider(uint64 dealID) public view returns (uint64) {
-        return MarketAPI.getDealProvider(dealID);
-    }
-
-    /// @dev returns the label for a deal
-    /// @param dealID the deal id
-    /// @return the label and if label isString for a deal
-    function dealLabel(uint64 dealID) public view returns (bytes memory, bool) {
-        CommonTypes.DealLabel memory label = MarketAPI.getDealLabel(dealID);
-        return (label.data, label.isString);
-    }
-
-    /// @dev returns the start and end epoch for a deal
-    /// @param dealID the deal id
-    /// @return the start and end epoch for a deal
-    function dealTerm(uint64 dealID) public view returns (int64, int64) {
-        MarketTypes.GetDealTermReturn memory term = MarketAPI.getDealTerm(
-            dealID
-        );
-        int64 start = CommonTypes.ChainEpoch.unwrap(term.start);
-        int64 end = CommonTypes.ChainEpoch.unwrap(term.end);
-        return (start, end);
-    }
-
-    /// @dev returns the total price paid for a deal
-    /// @param dealID the deal id
-    /// @return the total price paid for a deal
-    function dealTotalPrice(
-        uint64 dealID
-    ) public view returns (CommonTypes.BigInt memory) {
-        return MarketAPI.getDealTotalPrice(dealID);
-    }
-
-    /// @dev gives the client's collateral amount for a deal
-    /// @param dealID the deal id
-    /// @return the client collateral for a deal
-    function dealClientCollateral(
-        uint64 dealID
-    ) public view returns (CommonTypes.BigInt memory) {
-        return MarketAPI.getDealClientCollateral(dealID);
-    }
-
-    /// @dev gives the provider's collateral amount for a deal
-    /// @param dealID the deal id
-    /// @return the provider collateral for a deal
-    function dealProviderCollateral(
-        uint64 dealID
-    ) public view returns (CommonTypes.BigInt memory) {
-        return MarketAPI.getDealProviderCollateral(dealID);
-    }
-
-    /// @dev returns true if a deal is verified
-    /// @param dealID the deal id
-    /// @return verified
-    function dealVerified(uint64 dealID) public view returns (bool) {
-        return MarketAPI.getDealVerified(dealID);
-    }
-
-    /// @dev gives the activation period for a deal
-    /// @param dealID the deal id
-    /// @return start and end epoch for a deal
-    function dealActivation(uint64 dealID) public view returns (int64, int64) {
-        MarketTypes.GetDealActivationReturn memory activation = MarketAPI
-            .getDealActivation(dealID);
-
-        int64 activated = CommonTypes.ChainEpoch.unwrap(activation.activated);
-        int64 terminated = CommonTypes.ChainEpoch.unwrap(activation.terminated);
-        return (activated, terminated);
+        uint256 epoch
+    ) external view returns (string[] memory) {
+        return _cids[pub][epoch];
     }
 }

--- a/evm/basin_storage/test/BasinStorage.t.sol
+++ b/evm/basin_storage/test/BasinStorage.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.21;
 import {Test, console2} from "forge-std/Test.sol";
 import {BasinStorage} from "../src/BasinStorage.sol";
 
-contract BasinStorageAddDealsTest is Test {
+contract BasinStorageAddCIDTest is Test {
     BasinStorage public basinStorage;
 
     event CIDAdded(
@@ -15,12 +15,12 @@ contract BasinStorageAddDealsTest is Test {
 
     constructor() {
         basinStorage = new BasinStorage();
-        // give the contract the PUB_ADMIN_ROLE before adding a deal
+        // give the contract the PUB_ADMIN_ROLE before adding a cid
         basinStorage.grantRole(basinStorage.PUB_ADMIN_ROLE(), address(this));
     }
 
     function testAddCIDUnauthorized() public {
-        // Call the AddDeal function with an unauthorized account
+        // Call the AddCID function with an unauthorized account
         vm.prank(address(0));
 
         // Define the input parameters
@@ -38,7 +38,6 @@ contract BasinStorageAddDealsTest is Test {
         basinStorage.addCID(pub, cid, epoch);
     }
 
-    // Test the CreateDealInfo function
     function testAddCIDWithoutAddingPub() public {
         // Define the input parameters
         string memory pub = "123456";
@@ -69,7 +68,7 @@ contract BasinStorageAddDealsTest is Test {
 
         string[] memory cids = basinStorage.cidsAtTimestamp(pub, 1);
 
-        assertEq(cids.length, 2, "Number of deals should be 2");
+        assertEq(cids.length, 2, "Number of cids should be 2");
         assertEq(
             cids[0],
             "bafyfoobar1",
@@ -90,7 +89,7 @@ contract BasinStoragePubsTest is Test {
 
     constructor() {
         basinStorage = new BasinStorage();
-        // give the contract the PUB_ADMIN_ROLE before adding a deal
+        // give the contract the PUB_ADMIN_ROLE before adding a cid
         basinStorage.grantRole(basinStorage.PUB_ADMIN_ROLE(), address(this));
     }
 
@@ -138,7 +137,7 @@ contract BasinStoragePubsTest is Test {
 
 abstract contract HelperContract is Test {
     function setUpHelper(BasinStorage basinStorage) public {
-        // Create deals for pub 1, owner 1 (current contract)
+        // Create cids for pub 1, owner 1 (current contract)
         string memory pub = "123456";
         string memory cid1 = "bafyfoobar1";
         string memory cid2 = "bafyfoobar2";
@@ -150,7 +149,7 @@ abstract contract HelperContract is Test {
         basinStorage.addCID(pub, cid2, epoch1);
         basinStorage.addCID(pub, cid3, epoch1);
 
-        // Create deals for pub 2, owner 1 (current contract)
+        // Create cids for pub 2, owner 1 (current contract)
         pub = "654321";
         string memory cid4 = "bafyfoobar4";
         string memory cid5 = "bafyfoobar5";
@@ -162,7 +161,7 @@ abstract contract HelperContract is Test {
         basinStorage.addCID(pub, cid5, epoch2);
         basinStorage.addCID(pub, cid6, epoch2);
 
-        // Create deals for pub 3, owner 2 (address 0x123)
+        // Create cids for pub 3, owner 2 (address 0x123)
         pub = "111111";
         string memory cid7 = "bafyfoobar7";
         string memory cid8 = "bafyfoobar8";
@@ -204,57 +203,57 @@ contract BasinStorageCidsInRangeTest is Test, HelperContract {
     function testcidsInRange() public {
         string memory pub = "123456";
         // after 0, before 4, excluding both 0 and 5
-        string[] memory deals = basinStorage.cidsInRange(pub, 0, 4);
+        string[] memory cids = basinStorage.cidsInRange(pub, 0, 4);
 
-        assertEq(deals.length, 3, "Deals count should be 3");
-        assertEq(deals[0], "bafyfoobar1", "cid should be bafyfoobar1");
-        assertEq(deals[1], "bafyfoobar2", "cid should be bafyfoobar2");
-        assertEq(deals[2], "bafyfoobar3", "cid should be bafyfoobar3");
+        assertEq(cids.length, 3, "cids count should be 3");
+        assertEq(cids[0], "bafyfoobar1", "cid should be bafyfoobar1");
+        assertEq(cids[1], "bafyfoobar2", "cid should be bafyfoobar2");
+        assertEq(cids[2], "bafyfoobar3", "cid should be bafyfoobar3");
 
         // after 0, before 5, excluding both 0 and 5
-        deals = basinStorage.cidsInRange(pub, 0, 5);
-        assertEq(deals.length, 6, "Deals count should be 6");
-        assertEq(deals[0], "bafyfoobar1", "cid should be bafyfoobar1");
-        assertEq(deals[1], "bafyfoobar2", "cid should be bafyfoobar2");
-        assertEq(deals[2], "bafyfoobar3", "cid should be bafyfoobar3");
-        assertEq(deals[3], "bafyfoobar10", "cid should be bafyfoobar10");
-        assertEq(deals[4], "bafyfoobar11", "cid should be bafyfoobar11");
-        assertEq(deals[5], "bafyfoobar12", "cid should be bafyfoobar12");
+        cids = basinStorage.cidsInRange(pub, 0, 5);
+        assertEq(cids.length, 6, "cids count should be 6");
+        assertEq(cids[0], "bafyfoobar1", "cid should be bafyfoobar1");
+        assertEq(cids[1], "bafyfoobar2", "cid should be bafyfoobar2");
+        assertEq(cids[2], "bafyfoobar3", "cid should be bafyfoobar3");
+        assertEq(cids[3], "bafyfoobar10", "cid should be bafyfoobar10");
+        assertEq(cids[4], "bafyfoobar11", "cid should be bafyfoobar11");
+        assertEq(cids[5], "bafyfoobar12", "cid should be bafyfoobar12");
 
-        deals = basinStorage.cidsInRange(pub, 4, 5);
-        assertEq(deals.length, 0, "Deals count should be 0");
+        cids = basinStorage.cidsInRange(pub, 4, 5);
+        assertEq(cids.length, 0, "cids count should be 0");
 
         // after == before raises error
         vm.expectRevert(
             abi.encodeWithSelector(BasinStorage.IncorrectRange.selector, 1, 1)
         );
-        deals = basinStorage.cidsInRange(pub, 1, 1);
-        assertEq(deals.length, 0, "Deals count should be 0");
+        cids = basinStorage.cidsInRange(pub, 1, 1);
+        assertEq(cids.length, 0, "cids count should be 0");
 
         // after > before raises error
         vm.expectRevert(
             abi.encodeWithSelector(BasinStorage.IncorrectRange.selector, 5, 4)
         );
-        deals = basinStorage.cidsInRange(pub, 5, 4);
+        cids = basinStorage.cidsInRange(pub, 5, 4);
 
         pub = "654321"; // same owner different pub
-        deals = basinStorage.cidsInRange(pub, 0, 5);
-        assertEq(deals.length, 3, "Deals count should be 3");
-        assertEq(deals[0], "bafyfoobar4", "cid should be bafyfoobar4");
-        assertEq(deals[1], "bafyfoobar5", "cid should be bafyfoobar5");
-        assertEq(deals[2], "bafyfoobar6", "cid should be bafyfoobar6");
+        cids = basinStorage.cidsInRange(pub, 0, 5);
+        assertEq(cids.length, 3, "cids count should be 3");
+        assertEq(cids[0], "bafyfoobar4", "cid should be bafyfoobar4");
+        assertEq(cids[1], "bafyfoobar5", "cid should be bafyfoobar5");
+        assertEq(cids[2], "bafyfoobar6", "cid should be bafyfoobar6");
 
-        deals = basinStorage.cidsInRange(pub, 1, 3);
-        assertEq(deals.length, 3, "Deals count should be 3");
+        cids = basinStorage.cidsInRange(pub, 1, 3);
+        assertEq(cids.length, 3, "cids count should be 3");
 
-        deals = basinStorage.cidsInRange(pub, 1, 2);
-        assertEq(deals.length, 0, "Deals count should be 0");
+        cids = basinStorage.cidsInRange(pub, 1, 2);
+        assertEq(cids.length, 0, "cids count should be 0");
 
         pub = "111111"; // pub of diff owner: 0x123
-        deals = basinStorage.cidsInRange(pub, 2, 5);
-        assertEq(deals.length, 3, "Deals count should be 3");
-        assertEq(deals[0], "bafyfoobar7", "cid should be bafyfoobar7");
-        assertEq(deals[1], "bafyfoobar8", "cid should be bafyfoobar8");
-        assertEq(deals[2], "bafyfoobar9", "cid should be bafyfoobar9");
+        cids = basinStorage.cidsInRange(pub, 2, 5);
+        assertEq(cids.length, 3, "cids count should be 3");
+        assertEq(cids[0], "bafyfoobar7", "cid should be bafyfoobar7");
+        assertEq(cids[1], "bafyfoobar8", "cid should be bafyfoobar8");
+        assertEq(cids[2], "bafyfoobar9", "cid should be bafyfoobar9");
     }
 }

--- a/evm/basin_storage/test/BasinStorage.t.sol
+++ b/evm/basin_storage/test/BasinStorage.t.sol
@@ -7,11 +7,10 @@ import {BasinStorage} from "../src/BasinStorage.sol";
 contract BasinStorageAddDealsTest is Test {
     BasinStorage public basinStorage;
 
-    event DealAdded(
-        uint256 indexed dealId,
+    event CIDAdded(
+        string indexed cid,
         string indexed pub,
-        address indexed owner,
-        string cid
+        address indexed owner
     );
 
     constructor() {
@@ -20,19 +19,14 @@ contract BasinStorageAddDealsTest is Test {
         basinStorage.grantRole(basinStorage.PUB_ADMIN_ROLE(), address(this));
     }
 
-    function testAddDealUnauthorized() public {
+    function testAddCIDUnauthorized() public {
         // Call the AddDeal function with an unauthorized account
         vm.prank(address(0));
 
         // Define the input parameters
         string memory pub = "123456";
-        // BasinStorage.DealInfo memory dealInfo[] =
-        BasinStorage.DealInfo[] memory deals = new BasinStorage.DealInfo[](1);
-        deals[0] = BasinStorage.DealInfo({
-            id: 1,
-            selectorPath: "path/to/selector1",
-            cid: "bafyfoobar1"
-        });
+        uint256 epoch = block.timestamp;
+        string memory cid = "bafyfoobar1";
 
         string memory reason = string.concat(
             "AccessControl: account ",
@@ -41,84 +35,50 @@ contract BasinStorageAddDealsTest is Test {
             "0xafda658ee731b8f86292e3b52a311534cd93642b12a698012439316e0c3a0995"
         );
         vm.expectRevert(bytes(reason));
-        basinStorage.addDeals(pub, deals);
+        basinStorage.addCID(pub, cid, epoch);
     }
 
     // Test the CreateDealInfo function
-    function testAddDealWithoutAddingPub() public {
+    function testAddCIDWithoutAddingPub() public {
         // Define the input parameters
         string memory pub = "123456";
-        BasinStorage.DealInfo[] memory deals = new BasinStorage.DealInfo[](1);
-        deals[0] = BasinStorage.DealInfo({
-            id: 1,
-            selectorPath: "path/to/selector1",
-            cid: "bafyfoobar1"
-        });
-
+        string memory cid = "bafyfoobar1";
+        uint256 epoch = block.timestamp;
         vm.expectRevert(
             abi.encodeWithSelector(BasinStorage.PubDoesNotExist.selector, pub)
         );
-        basinStorage.addDeals(pub, deals);
+        basinStorage.addCID(pub, cid, epoch);
     }
 
-    function testAddDealEmptyInput() public {
+    function testAddCIDSuccess() public {
         string memory pub = "123456";
-        BasinStorage.DealInfo[] memory deals = new BasinStorage.DealInfo[](0);
-
-        basinStorage.createPub(address(this), pub);
-        basinStorage.addDeals(pub, deals);
-        deals = basinStorage.latestNDeals(pub, 2);
-        assertEq(deals.length, 0, "Number of deals should be 0");
-    }
-
-    function testAddDealSuccess() public {
-        string memory pub = "123456";
-        BasinStorage.DealInfo[] memory deals = new BasinStorage.DealInfo[](2);
-        deals[0] = BasinStorage.DealInfo({
-            id: 1,
-            selectorPath: "path/to/selector1",
-            cid: "bafyfoobar1"
-        });
-        deals[1] = BasinStorage.DealInfo({
-            id: 2,
-            selectorPath: "path/to/selector2",
-            cid: "bafyfoobar2"
-        });
-
+        uint256 epoch = block.timestamp;
+        string memory cid1 = "bafyfoobar1";
+        string memory cid2 = "bafyfoobar2";
         basinStorage.createPub(address(this), pub);
 
         // check that the 1st event is emitted
         vm.expectEmit(address(basinStorage));
-        emit BasinStorage.DealAdded(1, pub, address(this), "bafyfoobar1");
+        emit BasinStorage.CIDAdded("bafyfoobar1", pub, address(this));
+        basinStorage.addCID(pub, cid1, epoch);
 
         // check that the 2nd event is emitted
         vm.expectEmit(address(basinStorage));
-        emit BasinStorage.DealAdded(2, pub, address(this), "bafyfoobar2");
+        emit BasinStorage.CIDAdded("bafyfoobar2", pub, address(this));
+        basinStorage.addCID(pub, cid2, epoch);
 
-        basinStorage.addDeals(pub, deals);
-        deals = basinStorage.latestNDeals(pub, 2);
-        assertEq(deals.length, 2, "Number of deals should be 2");
-        assertEq(deals[0].id, 1, "Deal ID should be correct");
+        string[] memory cids = basinStorage.cidsAtTimestamp(pub, 1);
+
+        assertEq(cids.length, 2, "Number of deals should be 2");
         assertEq(
-            deals[0].selectorPath,
-            "path/to/selector1",
-            "Deal selector should be correct"
-        );
-        assertEq(
-            deals[0].cid,
+            cids[0],
             "bafyfoobar1",
-            "Deal content identifier should be correct"
-        );
-        assertEq(deals[1].id, 2, "Deal ID should be correct");
-        assertEq(
-            deals[1].selectorPath,
-            "path/to/selector2",
-            "Deal selector should be correct"
+            "content identifier should be correct"
         );
         assertEq(
-            deals[1].cid,
+            cids[1],
             "bafyfoobar2",
-            "Deal content identifier should be correct"
+            "content identifier should be correct"
         );
     }
 }
@@ -179,99 +139,61 @@ contract BasinStoragePubsTest is Test {
 abstract contract HelperContract is Test {
     function setUpHelper(BasinStorage basinStorage) public {
         // Create deals for pub 1, owner 1 (current contract)
-        vm.roll(0);
         string memory pub = "123456";
-        BasinStorage.DealInfo[] memory deals = new BasinStorage.DealInfo[](3);
-        deals[0] = BasinStorage.DealInfo({
-            id: 1,
-            selectorPath: "path/to/selector1",
-            cid: "bafyfoobar1"
-        });
-        deals[1] = BasinStorage.DealInfo({
-            id: 2,
-            selectorPath: "path/to/selector2",
-            cid: "bafyfoobar2"
-        });
-        deals[2] = BasinStorage.DealInfo({
-            id: 3,
-            selectorPath: "path/to/selector3",
-            cid: "bafyfoobar3"
-        });
+        string memory cid1 = "bafyfoobar1";
+        string memory cid2 = "bafyfoobar2";
+        string memory cid3 = "bafyfoobar3";
+        uint256 epoch1 = block.timestamp;
 
         basinStorage.createPub(address(this), pub);
-        basinStorage.addDeals(pub, deals);
+        basinStorage.addCID(pub, cid1, epoch1);
+        basinStorage.addCID(pub, cid2, epoch1);
+        basinStorage.addCID(pub, cid3, epoch1);
 
         // Create deals for pub 2, owner 1 (current contract)
-        vm.roll(100);
         pub = "654321";
-        deals[0] = BasinStorage.DealInfo({
-            id: 4,
-            selectorPath: "path/to/selector4",
-            cid: "bafyfoobar4"
-        });
-        deals[1] = BasinStorage.DealInfo({
-            id: 5,
-            selectorPath: "path/to/selector5",
-            cid: "bafyfoobar5"
-        });
-        deals[2] = BasinStorage.DealInfo({
-            id: 6,
-            selectorPath: "path/to/selector6",
-            cid: "bafyfoobar6"
-        });
+        string memory cid4 = "bafyfoobar4";
+        string memory cid5 = "bafyfoobar5";
+        string memory cid6 = "bafyfoobar6";
+        uint256 epoch2 = block.timestamp + 1;
+
         basinStorage.createPub(address(0x123), pub);
-        basinStorage.addDeals(pub, deals);
+        basinStorage.addCID(pub, cid4, epoch2);
+        basinStorage.addCID(pub, cid5, epoch2);
+        basinStorage.addCID(pub, cid6, epoch2);
 
         // Create deals for pub 3, owner 2 (address 0x123)
         pub = "111111";
-        vm.roll(150);
-        deals[0] = BasinStorage.DealInfo({
-            id: 7,
-            selectorPath: "path/to/selector7",
-            cid: "bafyfoobar7"
-        });
-        deals[1] = BasinStorage.DealInfo({
-            id: 8,
-            selectorPath: "path/to/selector8",
-            cid: "bafyfoobar8"
-        });
-        deals[2] = BasinStorage.DealInfo({
-            id: 9,
-            selectorPath: "path/to/selector9",
-            cid: "bafyfoobar9"
-        });
+        string memory cid7 = "bafyfoobar7";
+        string memory cid8 = "bafyfoobar8";
+        string memory cid9 = "bafyfoobar9";
+        uint256 epoch3 = block.timestamp + 2;
+
         basinStorage.createPub(address(this), pub);
-        basinStorage.addDeals(pub, deals);
+        basinStorage.addCID(pub, cid7, epoch3);
+        basinStorage.addCID(pub, cid8, epoch3);
+        basinStorage.addCID(pub, cid9, epoch3);
 
         // same pub as 123456 but on a different block
         pub = "123456";
-        vm.roll(200);
-        deals[0] = BasinStorage.DealInfo({
-            id: 10,
-            selectorPath: "path/to/selector10",
-            cid: "bafyfoobar10"
-        });
-        deals[1] = BasinStorage.DealInfo({
-            id: 11,
-            selectorPath: "path/to/selector11",
-            cid: "bafyfoobar11"
-        });
-        deals[2] = BasinStorage.DealInfo({
-            id: 12,
-            selectorPath: "path/to/selector12",
-            cid: "bafyfoobar12"
-        });
+        uint256 epoch4 = block.timestamp + 3;
+        string memory cid10 = "bafyfoobar10";
+        string memory cid11 = "bafyfoobar11";
+        string memory cid12 = "bafyfoobar12";
+
         // no creating pub if it already exists
-        basinStorage.addDeals(pub, deals);
+        basinStorage.addCID(pub, cid10, epoch4);
+        basinStorage.addCID(pub, cid11, epoch4);
+        basinStorage.addCID(pub, cid12, epoch4);
     }
 }
 
-contract BasinStoragePaginatedDealsTest is Test, HelperContract {
+contract BasinStorageCidsInRangeTest is Test, HelperContract {
     BasinStorage public basinStorage;
 
     constructor() {
         basinStorage = new BasinStorage();
-        // give the contract the PUB_ADMIN_ROLE before adding a deal
+        // give the contract the PUB_ADMIN_ROLE before adding a cid
         basinStorage.grantRole(basinStorage.PUB_ADMIN_ROLE(), address(this));
     }
 
@@ -279,190 +201,60 @@ contract BasinStoragePaginatedDealsTest is Test, HelperContract {
         HelperContract.setUpHelper(basinStorage);
     }
 
-    function testpaginatedDeals(uint16 offset, uint16 limit) public {
-        vm.assume(offset >= 0 && offset <= 200);
-
-        // get latest N deals where N > total deals for an epoch range
+    function testcidsInRange() public {
         string memory pub = "123456";
-        BasinStorage.DealInfo[] memory deals = basinStorage.paginatedDeals(
-            pub,
-            offset,
-            limit
-        );
+        // after 0, before 4, excluding both 0 and 5
+        string[] memory deals = basinStorage.cidsInRange(pub, 0, 4);
 
-        if (limit >= 6 && offset == 200) {
-            assertEq(deals.length, 6, "Deals count should be 6");
-            // from 2nd (newer) batch
-            assertEq(deals[0].id, 10, "Deal id should be 10");
-            assertEq(deals[1].id, 11, "Deal id should be 11");
-            assertEq(deals[2].id, 12, "Deal id should be 12");
-            // from 1st (older) batch
-            assertEq(deals[3].id, 1, "Deal id should be 1");
-            assertEq(deals[4].id, 2, "Deal id should be 2");
-            assertEq(deals[5].id, 3, "Deal id should be 3");
-        } else if (limit >= 6 && offset < 200) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 1, "Deal id should be 1");
-            assertEq(deals[1].id, 2, "Deal id should be 2");
-            assertEq(deals[2].id, 3, "Deal id should be 3");
-        } else if (limit > 3 && offset < 200) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 1, "Deal id should be 1");
-            assertEq(deals[1].id, 2, "Deal id should be 2");
-            assertEq(deals[2].id, 3, "Deal id should be 3");
-        } else if (limit < 3) {
-            assertEq(deals.length, limit, "Deals count should be == limit");
-        }
+        assertEq(deals.length, 3, "Deals count should be 3");
+        assertEq(deals[0], "bafyfoobar1", "cid should be bafyfoobar1");
+        assertEq(deals[1], "bafyfoobar2", "cid should be bafyfoobar2");
+        assertEq(deals[2], "bafyfoobar3", "cid should be bafyfoobar3");
+
+        // after 0, before 5, excluding both 0 and 5
+        deals = basinStorage.cidsInRange(pub, 0, 5);
+        assertEq(deals.length, 6, "Deals count should be 6");
+        assertEq(deals[0], "bafyfoobar1", "cid should be bafyfoobar1");
+        assertEq(deals[1], "bafyfoobar2", "cid should be bafyfoobar2");
+        assertEq(deals[2], "bafyfoobar3", "cid should be bafyfoobar3");
+        assertEq(deals[3], "bafyfoobar10", "cid should be bafyfoobar10");
+        assertEq(deals[4], "bafyfoobar11", "cid should be bafyfoobar11");
+        assertEq(deals[5], "bafyfoobar12", "cid should be bafyfoobar12");
+
+        deals = basinStorage.cidsInRange(pub, 4, 5);
+        assertEq(deals.length, 0, "Deals count should be 0");
+
+        // after == before raises error
+        vm.expectRevert(
+            abi.encodeWithSelector(BasinStorage.IncorrectRange.selector, 1, 1)
+        );
+        deals = basinStorage.cidsInRange(pub, 1, 1);
+        assertEq(deals.length, 0, "Deals count should be 0");
+
+        // after > before raises error
+        vm.expectRevert(
+            abi.encodeWithSelector(BasinStorage.IncorrectRange.selector, 5, 4)
+        );
+        deals = basinStorage.cidsInRange(pub, 5, 4);
 
         pub = "654321"; // same owner different pub
-        deals = basinStorage.paginatedDeals(pub, offset, limit);
-        // all 3 deals were added @ block number 100
-        if (offset < 100) {
-            assertEq(deals.length, 0, "Deals count should be 0");
-        } else if (offset >= 100 && limit > 3) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 4, "Deal id should be 4");
-            assertEq(deals[1].id, 5, "Deal id should be 5");
-            assertEq(deals[2].id, 6, "Deal id should be 6");
-        } else if (offset >= 100 && limit <= 3) {
-            assertEq(deals.length, limit, "Deals count should be == limit");
-        }
+        deals = basinStorage.cidsInRange(pub, 0, 5);
+        assertEq(deals.length, 3, "Deals count should be 3");
+        assertEq(deals[0], "bafyfoobar4", "cid should be bafyfoobar4");
+        assertEq(deals[1], "bafyfoobar5", "cid should be bafyfoobar5");
+        assertEq(deals[2], "bafyfoobar6", "cid should be bafyfoobar6");
 
-        pub = "111111"; // pub of 0x123
-        deals = basinStorage.paginatedDeals(pub, offset, limit);
-        // all 3 deals were added @ block number 150
-        if (offset < 150) {
-            assertEq(deals.length, 0, "Deals count should be 0");
-        } else if (offset >= 150 && limit > 3) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 7, "Deal id should be 7");
-            assertEq(deals[1].id, 8, "Deal id should be 8");
-            assertEq(deals[2].id, 9, "Deal id should be 9");
-        } else if (offset >= 150 && limit <= 3) {
-            assertEq(deals.length, limit, "Deals count should be == limit");
-        }
-    }
-}
+        deals = basinStorage.cidsInRange(pub, 1, 3);
+        assertEq(deals.length, 3, "Deals count should be 3");
 
-contract BasinStorageLatestDealsTest is Test, HelperContract {
-    BasinStorage public basinStorage;
+        deals = basinStorage.cidsInRange(pub, 1, 2);
+        assertEq(deals.length, 0, "Deals count should be 0");
 
-    constructor() {
-        basinStorage = new BasinStorage();
-        // give the contract the PUB_ADMIN_ROLE before adding a deal
-        basinStorage.grantRole(basinStorage.PUB_ADMIN_ROLE(), address(this));
-    }
-
-    function setUp() public {
-        HelperContract.setUpHelper(basinStorage);
-    }
-
-    function testLatestNDeals(uint16 n) public {
-        // get latest N deals where N > total deals
-        string memory pub = "123456";
-        BasinStorage.DealInfo[] memory deals = basinStorage.latestNDeals(
-            pub,
-            n
-        );
-
-        if (n > 6) {
-            assertEq(deals.length, 6, "Deals count should be 6");
-            // from 2nd (newer) batch
-            assertEq(deals[0].id, 10, "Deal id should be 10");
-            assertEq(deals[1].id, 11, "Deal id should be 11");
-            assertEq(deals[2].id, 12, "Deal id should be 12");
-            // from 1st (older) batch
-            assertEq(deals[3].id, 1, "Deal id should be 1");
-            assertEq(deals[4].id, 2, "Deal id should be 2");
-            assertEq(deals[5].id, 3, "Deal id should be 3");
-        } else {
-            assertEq(deals.length, n, "Deals count should be: n");
-        }
-
-        pub = "111111"; // pub of 0x123
-        deals = basinStorage.latestNDeals(pub, n);
-        if (n > 3) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 7, "Deal id should be 10");
-            assertEq(deals[1].id, 8, "Deal id should be 11");
-            assertEq(deals[2].id, 9, "Deal id should be 12");
-        } else {
-            assertEq(deals.length, n, "Deals count should be: n");
-        }
-
-        pub = "654321";
-        deals = basinStorage.latestNDeals(pub, n);
-        if (n > 3) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 4, "Deal id should be 4");
-            assertEq(deals[1].id, 5, "Deal id should be 5");
-            assertEq(deals[2].id, 6, "Deal id should be 6");
-        } else {
-            assertEq(deals.length, n, "Deals count should be: n");
-        }
-    }
-
-    function testpaginatedDeals(uint16 offset, uint16 limit) public {
-        vm.assume(offset >= 0 && offset <= 200);
-
-        // get latest N deals where N > total deals for an epoch range
-        string memory pub = "123456";
-        BasinStorage.DealInfo[] memory deals = basinStorage.paginatedDeals(
-            pub,
-            offset,
-            limit
-        );
-
-        if (limit >= 6 && offset == 200) {
-            assertEq(deals.length, 6, "Deals count should be 6");
-            // from 2nd (newer) batch
-            assertEq(deals[0].id, 10, "Deal id should be 10");
-            assertEq(deals[1].id, 11, "Deal id should be 11");
-            assertEq(deals[2].id, 12, "Deal id should be 12");
-            // from 1st (older) batch
-            assertEq(deals[3].id, 1, "Deal id should be 1");
-            assertEq(deals[4].id, 2, "Deal id should be 2");
-            assertEq(deals[5].id, 3, "Deal id should be 3");
-        } else if (limit >= 6 && offset < 200) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 1, "Deal id should be 1");
-            assertEq(deals[1].id, 2, "Deal id should be 2");
-            assertEq(deals[2].id, 3, "Deal id should be 3");
-        } else if (limit > 3 && offset < 200) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 1, "Deal id should be 1");
-            assertEq(deals[1].id, 2, "Deal id should be 2");
-            assertEq(deals[2].id, 3, "Deal id should be 3");
-        } else if (limit < 3) {
-            assertEq(deals.length, limit, "Deals count should be == limit");
-        }
-
-        pub = "654321"; // same owner different pub
-        deals = basinStorage.paginatedDeals(pub, offset, limit);
-        // all 3 deals were added @ block number 100
-        if (offset < 100) {
-            assertEq(deals.length, 0, "Deals count should be 0");
-        } else if (offset >= 100 && limit > 3) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 4, "Deal id should be 4");
-            assertEq(deals[1].id, 5, "Deal id should be 5");
-            assertEq(deals[2].id, 6, "Deal id should be 6");
-        } else if (offset >= 100 && limit <= 3) {
-            assertEq(deals.length, limit, "Deals count should be == limit");
-        }
-
-        pub = "111111"; // pub of 0x123
-        deals = basinStorage.paginatedDeals(pub, offset, limit);
-        // all 3 deals were added @ block number 150
-        if (offset < 150) {
-            assertEq(deals.length, 0, "Deals count should be 0");
-        } else if (offset >= 150 && limit > 3) {
-            assertEq(deals.length, 3, "Deals count should be 3");
-            assertEq(deals[0].id, 7, "Deal id should be 7");
-            assertEq(deals[1].id, 8, "Deal id should be 8");
-            assertEq(deals[2].id, 9, "Deal id should be 9");
-        } else if (offset >= 150 && limit <= 3) {
-            assertEq(deals.length, limit, "Deals count should be == limit");
-        }
+        pub = "111111"; // pub of diff owner: 0x123
+        deals = basinStorage.cidsInRange(pub, 2, 5);
+        assertEq(deals.length, 3, "Deals count should be 3");
+        assertEq(deals[0], "bafyfoobar7", "cid should be bafyfoobar7");
+        assertEq(deals[1], "bafyfoobar8", "cid should be bafyfoobar8");
+        assertEq(deals[2], "bafyfoobar9", "cid should be bafyfoobar9");
     }
 }


### PR DESCRIPTION
This PR add the new Basin Storage contract that indexes with `CID`s instead of Deals. We have decided to index CIDs because deal IDs can be retrieved from the Filecoin network if CIDs are known. 

## Summary
1. Creating and getting pub part remains the same.
2. `AddDeals(pub, dealInfo[])` function has changed to `AddCID(pub, cid, timestamp)`.
3. The main index data structure is same. But instead of block number, the index will use caller provider timestamps.
4. Removes the Filecoin solidity dependencies since we are not working with Deals anymore.
5. Adds cast commands to interact with the contract in README.
6. Instead of `latestNDeals` and `paginatedDeals` functions the contract now exposes `cidsAtTimestamp` and `cidsInRange` functions.
 