### PR TITLE
adds cache suppport

### DIFF
--- a/pkg/storage/test_utils.go
+++ b/pkg/storage/test_utils.go
@@ -143,7 +143,9 @@ type mockCrdb struct {
 	jobs []UnfinishedJob
 }
 
-func (m *mockCrdb) CreateJob(_ context.Context, cidStr string, fname string, timestamp *int64) error {
+func (m *mockCrdb) CreateJob(
+	_ context.Context, cidStr string, fname string, timestamp *int64, cacheDuration int64,
+) error {
 	cid, _ := cid.Decode(cidStr)
 	pub, err := extractPub(fname)
 	if err != nil {
@@ -154,6 +156,7 @@ func (m *mockCrdb) CreateJob(_ context.Context, cidStr string, fname string, tim
 		Cid:       cid.Bytes(),
 		Activated: time.Time{},
 		Timestamp: timestamp,
+		ExpiresAt: time.Unix(*timestamp+cacheDuration, 0),
 	})
 	return nil
 }

--- a/pkg/storage/uploader.go
+++ b/pkg/storage/uploader.go
@@ -112,7 +112,16 @@ func (u *FileUploader) Upload(ctx context.Context) error {
 		timestamp = &t
 	}
 
-	err = u.DBClient.CreateJob(ctx, cid.String(), fname, timestamp)
+	var cacheDutation int64
+	if _, ok := metadata["cache_duration"]; ok {
+		duration, err := strconv.ParseInt(metadata["cache_duration"], 10, 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse timestamp: %v", err)
+		}
+		cacheDutation = duration
+	}
+
+	err = u.DBClient.CreateJob(ctx, cid.String(), fname, timestamp, cacheDutation)
 	if err != nil {
 		return fmt.Errorf("failed to create deal: %v", err)
 	}

--- a/pkg/storage/uploader_test.go
+++ b/pkg/storage/uploader_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io/fs"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/tablelandnetwork/basin-storage/mocks"
@@ -23,8 +24,9 @@ func TestUploader(t *testing.T) {
 	// Mocking the returned reader for the GetObjectReader method
 	mockReadCloser := &MockReadCloser{Reader: bytes.NewReader(mockData())}
 	mockGCS.On("GetObjectReader", ctx, "mybucket", fname).Return(mockReadCloser, nil)
-
-	mockGCS.On("GetObjectMetadata", ctx, "mybucket", fname).Return(map[string]string{"timestamp": "1234"}, nil)
+	mockGCS.On("GetObjectMetadata", ctx, "mybucket", fname).Return(
+		map[string]string{"timestamp": "1700248832", "cache_duration": "100"}, nil,
+	)
 
 	uploader := FileUploader{
 		StorageClient: mockGCS,
@@ -71,5 +73,6 @@ func TestUploader(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, getCIDFromBytes(mockData()).String(), cid.String())
 
-	assert.Equal(t, int64(1234), *jobs[0].Timestamp)
+	assert.Equal(t, int64(1700248832), *jobs[0].Timestamp)
+	assert.Equal(t, time.Unix(1700248832+100, 0), jobs[0].ExpiresAt)
 }

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -89,10 +89,24 @@ func setupDB(t *testing.T, db *sql.DB) {
 			relation TEXT NOT NULL,
 			activated TIMESTAMP,
 			timestamp BIGINT,
+			cache_path TEXT,
+			expires_at TIMESTAMP,
 			CONSTRAINT fk_namespace
 			FOREIGN KEY(ns_id)
 			REFERENCES namespaces(id)
 		)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(
+		`CREATE TABLE IF NOT EXISTS cache_config
+		(
+			ns_id BIGINT NOT NULL,
+			relation TEXT NOT NULL,
+			duration BIGINT,
+			CONSTRAINT fk_namespace
+			FOREIGN KEY(ns_id)
+			REFERENCES namespaces(id)
+		);`)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This PR accepts a `cache_duration` metadata, calculates the `expires_at` and storage that in the provider's db. See https://github.com/tablelandnetwork/basin-provider/pull/16 for more context

Note: test is failing because, the integration test runs on the Coackroach DB instance, when migration was not run on that yet.