### PR TITLE
Persist hash and sign for an upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ uploader-deploy:
 	--region=us-east1 \
 	--source=. \
 	--entry-point=Uploader \
-	--trigger-event-filters="type=google.cloud.storage.object.v1.finalized" \
+	--trigger-event-filters="type=google.cloud.storage.object.v1.metadataUpdated" \
 	--trigger-event-filters="bucket=tableland-basin-staging"  \
 	--memory 32768MB \
-	--timeout 3600s \
+	--timeout 540s \
 	--env-vars-file uploader.env.yml
 .PHONY: uploader-deploy
 

--- a/go.mod
+++ b/go.mod
@@ -132,7 +132,7 @@ require (
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
-	golang.org/x/sync v0.3.0
+	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect

--- a/pkg/storage/crdb.go
+++ b/pkg/storage/crdb.go
@@ -3,12 +3,12 @@ package storage
 import (
 	"context"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ipfs/go-cid"
 
 	// Blank-import libpq package for SQL.
@@ -41,12 +41,12 @@ func createJobTx(
 		_ = cachePath.Scan(fname)
 	}
 
-	signBytes, err := hexutil.Decode("0x" + sign)
+	signBytes, err := hex.DecodeString(sign)
 	if err != nil {
 		return errors.Wrap(err, "decoding sign")
 	}
 
-	hashBytes, err := hexutil.Decode("0x" + hash)
+	hashBytes, err := hex.DecodeString(hash)
 	if err != nil {
 		return errors.Wrap(err, "decoding hash")
 	}

--- a/pkg/storage/crdb.go
+++ b/pkg/storage/crdb.go
@@ -53,7 +53,7 @@ func createJobTx(
 
 	_, err = tx.Exec(
 		`insert into jobs (
-			ns_id, cid, relation, timestamp, cache_path, expires_at, sign, hash
+			ns_id, cid, relation, timestamp, cache_path, expires_at, signature, hash
 		) 
 		values (
 			$1, $2, $3, $4, $5, $6, $7, $8

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -57,6 +57,6 @@ func (r *GCSClient) ParseEvent() (string, string, error) {
 	if err := protojson.Unmarshal(r.EventData, &data); err != nil {
 		return "", "", fmt.Errorf("protojson.Unmarshal: %w", err)
 	}
-	fmt.Println(data.GetMetadata())
+
 	return data.GetBucket(), data.GetName(), nil
 }

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -57,6 +57,6 @@ func (r *GCSClient) ParseEvent() (string, string, error) {
 	if err := protojson.Unmarshal(r.EventData, &data); err != nil {
 		return "", "", fmt.Errorf("protojson.Unmarshal: %w", err)
 	}
-
+	fmt.Println(data.GetMetadata())
 	return data.GetBucket(), data.GetName(), nil
 }

--- a/pkg/storage/test_utils.go
+++ b/pkg/storage/test_utils.go
@@ -144,7 +144,13 @@ type mockCrdb struct {
 }
 
 func (m *mockCrdb) CreateJob(
-	_ context.Context, cidStr string, fname string, timestamp *int64, cacheDuration int64,
+	_ context.Context,
+	cidStr string,
+	fname string,
+	timestamp *int64,
+	cacheDuration int64,
+	_ string,
+	_ string,
 ) error {
 	cid, _ := cid.Decode(cidStr)
 	pub, err := extractPub(fname)

--- a/pkg/storage/uploader.go
+++ b/pkg/storage/uploader.go
@@ -133,7 +133,7 @@ func (u *FileUploader) Upload(ctx context.Context) error {
 
 	err = u.DBClient.CreateJob(ctx, cid.String(), fname, timestamp, cacheDutation, sign, hash)
 	if err != nil {
-		return fmt.Errorf("failed to create deal: %v", err)
+		return err
 	}
 
 	fmt.Println("DB insert successful", fname)

--- a/pkg/storage/uploader.go
+++ b/pkg/storage/uploader.go
@@ -121,7 +121,17 @@ func (u *FileUploader) Upload(ctx context.Context) error {
 		cacheDutation = duration
 	}
 
-	err = u.DBClient.CreateJob(ctx, cid.String(), fname, timestamp, cacheDutation)
+	sign, ok := metadata["signature"]
+	if !ok {
+		return fmt.Errorf("signature is missing")
+	}
+
+	hash, ok := metadata["hash"]
+	if !ok {
+		return fmt.Errorf("hash is missing")
+	}
+
+	err = u.DBClient.CreateJob(ctx, cid.String(), fname, timestamp, cacheDutation, sign, hash)
 	if err != nil {
 		return fmt.Errorf("failed to create deal: %v", err)
 	}

--- a/pkg/storage/uploader_test.go
+++ b/pkg/storage/uploader_test.go
@@ -25,7 +25,7 @@ func TestUploader(t *testing.T) {
 	mockReadCloser := &MockReadCloser{Reader: bytes.NewReader(mockData())}
 	mockGCS.On("GetObjectReader", ctx, "mybucket", fname).Return(mockReadCloser, nil)
 	metadata := map[string]string{
-		"timestamp":      "1234",
+		"timestamp":      "1700248832",
 		"cache_duration": "100",
 		"signature":      "25ee57b44817278828f3ad3f47dfe440cf2f729524b7ae445a933cf78e22d8583084048b47676f8c64daae85b937dda79ee2596b924710eebbff94652e5e2f9500", // nolint:lll
 		"hash":           "f00a989b4f86fd3bd6d347b03c59bba377bcaac57f3b43addfad9da1bca51938",

--- a/pkg/storage/uploader_test.go
+++ b/pkg/storage/uploader_test.go
@@ -24,9 +24,13 @@ func TestUploader(t *testing.T) {
 	// Mocking the returned reader for the GetObjectReader method
 	mockReadCloser := &MockReadCloser{Reader: bytes.NewReader(mockData())}
 	mockGCS.On("GetObjectReader", ctx, "mybucket", fname).Return(mockReadCloser, nil)
-	mockGCS.On("GetObjectMetadata", ctx, "mybucket", fname).Return(
-		map[string]string{"timestamp": "1700248832", "cache_duration": "100"}, nil,
-	)
+	metadata := map[string]string{
+		"timestamp":      "1234",
+		"cache_duration": "100",
+		"signature":      "25ee57b44817278828f3ad3f47dfe440cf2f729524b7ae445a933cf78e22d8583084048b47676f8c64daae85b937dda79ee2596b924710eebbff94652e5e2f9500", // nolint:lll
+		"hash":           "f00a989b4f86fd3bd6d347b03c59bba377bcaac57f3b43addfad9da1bca51938",
+	}
+	mockGCS.On("GetObjectMetadata", ctx, "mybucket", fname).Return(metadata, nil)
 
 	uploader := FileUploader{
 		StorageClient: mockGCS,

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -42,6 +42,17 @@ func uploadRandomBytesToGCS(t *testing.T, data []byte, bucketName, objectName st
 	_, err = wc.Write(data)
 	require.NoError(t, err)
 	require.NoError(t, wc.Close())
+
+	// Set the metadata
+	metadata := map[string]string{
+		"signature": "25ee57b44817278828f3ad3f47dfe440cf2f729524b7ae445a933cf78e22d8583084048b47676f8c64daae85b937dda79ee2596b924710eebbff94652e5e2f9500", // nolint
+		"hash":      "f00a989b4f86fd3bd6d347b03c59bba377bcaac57f3b43addfad9da1bca51938",                                                                   // nolint
+	}
+	attrs := storage.ObjectAttrsToUpdate{
+		Metadata: metadata,
+	}
+	_, err = object.Update(ctx, attrs)
+	require.NoError(t, err)
 }
 
 func deleteObjectFromGCS(t *testing.T, bucketName, objectName string) {
@@ -91,6 +102,8 @@ func setupDB(t *testing.T, db *sql.DB) {
 			timestamp BIGINT,
 			cache_path TEXT,
 			expires_at TIMESTAMP,
+			sign bytea,
+			hash bytea,
 			CONSTRAINT fk_namespace
 			FOREIGN KEY(ns_id)
 			REFERENCES namespaces(id)

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -102,7 +102,7 @@ func setupDB(t *testing.T, db *sql.DB) {
 			timestamp BIGINT,
 			cache_path TEXT,
 			expires_at TIMESTAMP,
-			sign bytea,
+			signature bytea,
 			hash bytea,
 			CONSTRAINT fk_namespace
 			FOREIGN KEY(ns_id)

--- a/tests/uploader_test.go
+++ b/tests/uploader_test.go
@@ -47,7 +47,7 @@ func buildUploadRequest(t *testing.T, bucketName, objectName string) *http.Reque
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("ce-id", "1234567890")
 	req.Header.Set("ce-specversion", "1.0")
-	req.Header.Set("ce-type", "google.cloud.storage.object.v1.finalized")
+	req.Header.Set("ce-type", "google.cloud.storage.object.v1.metadataUpdated")
 	req.Header.Set("ce-time", "2020-08-08T00:11:44.895529672Z")
 	req.Header.Set("ce-source", source)
 


### PR DESCRIPTION
- The hash and signature of the upload is present in the metadata. In this PR, we will extract the signature and hash and store it in the DB. 
- The Uploader will not be trigger by `google.cloud.storage.object.v1.metadataUpdated` instead of `google.cloud.storage.object.v1.finalized` event because the provider updates the file metadata in a separate request after the file upload is finished.
- Depends on https://github.com/tablelandnetwork/basin-provider/pull/19 for migrations

